### PR TITLE
Made sure to give back connections to the pool

### DIFF
--- a/src/main/scala/FinagleRedisSampleApp.scala
+++ b/src/main/scala/FinagleRedisSampleApp.scala
@@ -5,29 +5,16 @@ import com.twitter.util.{Await, Future}
 
 object FinagleRedisSampleApp extends App with SimpleCommands {
 
-  // The Redis client is built using a service factory, so let's construct one first
-  val serviceFactory = Redis.newClient("localhost:6379")
-
-  // For building a Redis client you can wrap a call to the Redis service factory
-  // into a Redis base client (using redis.Client). All of this is done as a
-  // concatenated futures using flatMap
-  def buildRedisClient = serviceFactory.apply() flatMap {
-    service =>
-      val redisClient = redis.Client(service)
-      Future.value(redisClient)
-  }
+  // Let's build a redis client
+  val redisClient = Redis.newRichClient("localhost:6379")
 
   // A simple sample that will store "one" in Redis associated with the key "key:1"
   // using the SET command and retrieve the value using the GET command. The important
   // part here is that the GET command should be attemped once the SET command is complete
   // that is why we concatenate the future of the SET command to the future of the GET
-  // command using flatMap, and by the way all of that composed with the Redis client
-  // build itself using again flatMap ... that's the beauty of Future: it compose very good
-  val storeAndRetrieveSample = buildRedisClient flatMap {
-    redisClient =>
-      simpleSet(redisClient, "key:1", "one") flatMap {
-        case _ => simpleGet(redisClient, "key:1")
-      }
+  // command using flatMap
+  val storeAndRetrieveSample = simpleSet(redisClient, "key:1", "one") flatMap {
+    case _ => simpleGet(redisClient, "key:1")
   }
 
   // Once the futures of our store and retrieve sample are set we just need to
@@ -44,29 +31,37 @@ object FinagleRedisSampleApp extends App with SimpleCommands {
 
   // We wait for store and retreive sample to complete. This is not mandatory
   // since we can make just one Await.ready call at the end of all samples using
-  // Future.join
+  // Future.join.  This would be dangerous to do from within a finagle service,
+  // like if we were serving responses, but is OK to do from within a script,
+  // because we control the thread that we're on.
   Await.ready(storeAndRetrieveSample)
 
   // Now let's create a queue sample with a listener of any value at the list with
   // the key "queue:1" and with some values pushed directly in this same sample.
-  // It's important to notice that the order of the listener and the push sample is
-  // not relevant and actually they are executed in paralel and Redis will warranty
-  // that if the push arrives first the values will be kept at Redis until the
-  // listener is active and if the listener arrives first it will loop until the
-  // values are pushed, and actually it will wait forever for the pushes so
+  // It's important to notice that depending on the way that the redis client is set up,
+  // the order of the listener and the push sample may or may not matter.  Using the
+  // finagle 6 APIs, ie Redis.new{Service,Client,RichClient}, it will use the pipelining
+  // dispatcher, which will only make one tcp connection per redis host, and then
+  // requests to the same host (in this case there's only one) will be sequenced.
+  // Using the ClientBuilder API, the order is not relevant, and since there are multiple
+  // tcp connections, we can't be guaranteed of which request Redis will see first.
+  // Redis will guarantee that if the push arrives first the values will be kept at
+  // Redis until the listener is active and if the listener arrives first it will loop
+  // until the values are pushed, and actually it will wait forever for the pushes so
   // you can issue an RPUSH command using the key "queue:1" from any other Redis
   // client and see the values just pop here
+  //
+  // One caveat is that finagle assumes that destinations are exchangeable, so
+  // if you specify "localhost:6379,localhost:6380" then pushing and then pulling
+  // from the queue may end up on different machines, unless they're set up as replicas,
+  // so you may perceive that you can't read your own writes.
   val queueKey = "queue:1"
-  val queueListenerSample = buildRedisClient flatMap {
-    redisClient =>
-      simpleQueueListener(redisClient, queueKey)
-  }
-  val queuePushSample = buildRedisClient flatMap {
-    redisClient =>
-      val push200 = (1 to 200) map { i =>
-        simpleQueuePush(redisClient, queueKey, i.toString)
-      }
-      Future.collect(push200)
+  val queueListenerSample = simpleQueueListener(redisClient, queueKey)
+  val queuePushSample = {
+    val push200 = (1 to 200) map { i =>
+      simpleQueuePush(redisClient, queueKey, i.toString)
+    }
+    Future.collect(push200)
   }
 
   // Only report on failure events since the listener is an eternal loop that
@@ -88,5 +83,4 @@ object FinagleRedisSampleApp extends App with SimpleCommands {
   // and only stops if a failure is receives, but as an example of the Future.join
   // combinator here you have a sample
   Await.ready(Future.join(queueListenerSample, queuePushSample))
-
 }


### PR DESCRIPTION
## Problem

Finagle has a connection pool, which will pool connections for you, but in the example, connections were never given back to the pool.  This will confuse load balancing, and connection pool management, and make things a little trickier in general.
## Solution

Requests normally look like:

``` scala
serviceFactory() flatMap { svc =>
  svc.apply(redisCommand) ensure {
    svc.close()
  }
}
```

We can do it in an even more concise way, à la

``` scala
serviceFactory.toService
```

And it's actually built into the default Redis Client construction too.

``` scala
Redis.newRichClient(dest)
```

So I chose to use that.
## Result

Because we give connections back to the pool, finagle has a better sense of what's actually going on, and can loadbalance and drain better.  The code has also become more concise since we no longer have to manually construct the underlying redis `Service` every time.
